### PR TITLE
Updates for JuMP v0.21

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,8 @@ os:
   - osx
 julia:
   - 1.0
-  - 1.1
-  - 1.2
+  - 1.3
+  - nightly
+jobs:
+  allow_failures:
+    - julia: nightly

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MINLPTests"
 uuid = "ee0a3090-8ee9-5cdb-b8cb-8eeba3165522"
 repo = "https://github.com/JuliaOpt/MINLPTests.jl.git"
-version = "0.5.0"
+version = "0.5.1"
 
 [deps]
 JuMP = "4076af6c-e467-56ae-b986-b466b2749572"
@@ -9,7 +9,7 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
 Ipopt = "≥ 0.6"
-JuMP = "~0.20"
+JuMP = "~0.20, ~0.21"
 Juniper = "≥ 0.4"
 julia = "^1"
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -11,14 +11,14 @@ const POLY_SOLVERS = [IPOPT]
 const MIPOLY_SOLVERS = [JUNIPER]
 
 @testset "JuMP Model Tests" begin
-    @testset "$(solver.constructor): nlp" for solver in NLP_SOLVERS
+    @testset "$(solver): nlp" for solver in NLP_SOLVERS
         #MINLPTests.test_nlp(solver)
         MINLPTests.test_nlp(solver, exclude = [
             "005_011",  # Uses the function `\`
         ])
         MINLPTests.test_nlp_cvx(solver)
     end
-    @testset "$(solver.constructor): nlp_mi" for solver in MINLP_SOLVERS
+    @testset "$(solver): nlp_mi" for solver in MINLP_SOLVERS
         #MINLPTests.test_nlp_mi(solver)
         MINLPTests.test_nlp_mi(solver, exclude = [
             "003_013",  # Bug in Juniper - handling of expression graph?
@@ -27,11 +27,11 @@ const MIPOLY_SOLVERS = [JUNIPER]
         ])
         MINLPTests.test_nlp_mi_cvx(solver)
     end
-    @testset "$(solver.constructor): poly" for solver in POLY_SOLVERS
+    @testset "$(solver): poly" for solver in POLY_SOLVERS
         MINLPTests.test_poly(solver)
         MINLPTests.test_poly_cvx(solver)
     end
-    @testset "$(solver.constructor): poly_mi" for solver in MIPOLY_SOLVERS
+    @testset "$(solver): poly_mi" for solver in MIPOLY_SOLVERS
         MINLPTests.test_poly_mi(solver)
         MINLPTests.test_poly_mi_cvx(solver)
     end


### PR DESCRIPTION
Dropping `.constructor` from `$(solver.constructor)` appears to be backward compatible.